### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
         node: ['10.x', '12.x', '14.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
+    timeout-minutes: 60
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI_JOB_NUMBER: 1
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
       - uses: andresz1/size-limit-action@v1


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259